### PR TITLE
Fix HIGH_RESOLUTION directive

### DIFF
--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -352,39 +352,39 @@ kxtj3_status_t KXTJ3::standby(bool _en)
 //****************************************************************************//
 void KXTJ3::startupDelay(void)
 {
-#ifdef HIGH_RESOLUTION
-  if (accelSampleRate < 1)
-    delay(1300);
-  else if (accelSampleRate < 3)
-    delay(650);
-  else if (accelSampleRate < 6)
-    delay(330);
-  else if (accelSampleRate < 12)
-    delay(170);
-  else if (accelSampleRate < 25)
-    delay(90);
-  else if (accelSampleRate < 50)
-    delay(45);
-  else if (accelSampleRate < 100)
-    delay(25);
-  else if (accelSampleRate < 200)
-    delay(11);
-  else if (accelSampleRate < 400)
-    delay(6);
-  else if (accelSampleRate < 800)
-    delay(4);
-  else if (accelSampleRate < 1600)
-    delay(3);
-  else
-    delay(2);
-#else
-  if (accelSampleRate < 800 && accelSampleRate > 200)
-    delay(4);
-  else if (accelSampleRate < 1600 && accelSampleRate > 400)
-    delay(3);
-  else
-    delay(2);
-#endif
+  if (highRes) {
+    if (accelSampleRate < 1)
+      delay(1300);
+    else if (accelSampleRate < 3)
+      delay(650);
+    else if (accelSampleRate < 6)
+      delay(330);
+    else if (accelSampleRate < 12)
+      delay(170);
+    else if (accelSampleRate < 25)
+      delay(90);
+    else if (accelSampleRate < 50)
+      delay(45);
+    else if (accelSampleRate < 100)
+      delay(25);
+    else if (accelSampleRate < 200)
+      delay(11);
+    else if (accelSampleRate < 400)
+      delay(6);
+    else if (accelSampleRate < 800)
+      delay(4);
+    else if (accelSampleRate < 1600)
+      delay(3);
+    else
+      delay(2);
+  } else {
+    if (accelSampleRate < 800 && accelSampleRate > 200)
+      delay(4);
+    else if (accelSampleRate < 1600 && accelSampleRate > 400)
+      delay(3);
+    else
+      delay(2);
+  }
 }
 
 //****************************************************************************//
@@ -435,9 +435,9 @@ void KXTJ3::applySettings(void)
   // LOW power, 8-bit mode
   dataToWrite = 0x80;
 
-#ifdef HIGH_RESOLUTION
-  dataToWrite = 0xC0;
-#endif
+  if (highRes) {
+    dataToWrite = 0xC0;
+  }
 
   //  Convert scaling
   switch (accelRange) {

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -105,6 +105,11 @@ class KXTJ3
   kxtj3_status_t standby(bool _en = true);
 
   private:
+#ifdef HIGH_RESOLUTION
+  bool highRes = true;
+#else
+  bool highRes = false;
+#endif
   uint8_t I2CAddress;
   float accelSampleRate; // Sample Rate - 0.781, 1.563, 3.125, 6.25, 12.5, 25,
                          // 50, 100, 200, 400, 800, 1600Hz
@@ -117,7 +122,6 @@ class KXTJ3
   //   a chunk of memory into that array.
   kxtj3_status_t readRegisterRegion(uint8_t *, uint8_t, uint8_t);
 
-  private:
   // Start-up delay for coming out of standby or RAM reset
   void startupDelay(void);
 };


### PR DESCRIPTION
This fixes the broken HIGH_RESOLUTION preprocessor directive by having the header define a private boolean variable with its state, thus allowing the CPP file to use that boolean the same way it would have used the preprocessor directive. In this way, compatibility with existing sketches is not impacted.

Resolves #6 