### PR TITLE
Interrupt, Debug, Example updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Operating mode (HZ) | Low Power | High Resolution
 
 ## Interrupt Threshold
 
-Interrupt threshold sensitivity is compared to the top 12bits of the accelerometer 8g output value regardless of the resolution chosen:
+Interrupt threshold sensitivity is compared to the top 12bits of the accelerometer 8g output value regardless of the resolution chosen.
 
 > This value can be anything from 1 to 4095
 
@@ -40,7 +40,11 @@ Interrupt threshold sensitivity is compared to the top 12bits of the acceleromet
 
 ## Interrupt Duration
 
-Interrupt event duration to trigger the interrupt pin is a function of events and Sample Rate:
+Interrupt event duration to trigger the interrupt pin is a function of events and Sample Rate.
+
+Please note that in the context of Interrupt Duration, only Sample Rates up to 100 Hz are supported.
+
+If the IMU is set to a Sample Rate greater than 100 Hz, Interrupt Duration will use 100 Hz for its calculation.
 
 > This value can be anything from 1 to 255
 
@@ -48,7 +52,11 @@ Interrupt event duration to trigger the interrupt pin is a function of events an
 
 ## Non-Activity Duration
 
-Interrupt non-activity duration to *reset* the interrupt pin is a function of events and Sample Rate:
+Interrupt non-activity duration to *reset* the interrupt pin is a function of events and Sample Rate.
+
+As with Interrupt Duration, please note that only Sample Rates up to 100 Hz are supported.
+
+If the IMU is set to a Sample Rate greater than 100 Hz, Non-Activity Duration will use 100 Hz for its calculation.
 
 > This value can be anything from 1 to 255
 

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -9,15 +9,15 @@ Uses Wire.h for i2c operation
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
-// Accelerometer provides different Power modes by changing output bit
-// resolution
+// Accelerometer provides different power modes by changing output resolution
+// bit
 #define LOW_POWER
 //#define HIGH_RESOLUTION
 
-// Enable Serial debbug on Serial UART to see registers wrote
+// Enable Serial debug on Serial UART to see registers written
 #define KXTJ3_DEBUG Serial
 
-#include "Wire.h"
+// Include the KXTJ3-1057 library (includes Wire.h)
 #include "kxtj3-1057.h"
 
 float sampleRate =
@@ -35,13 +35,10 @@ void setup()
   delay(1000); // wait until serial is open...
 
   if (myIMU.begin(sampleRate, accelRange) != 0) {
-    Serial.print("Failed to initialize IMU.\n");
+    Serial.println("Failed to initialize IMU.");
   } else {
-    Serial.print("IMU initialized.\n");
+    Serial.println("IMU initialized.");
   }
-
-  // Detection threshold, movement duration and polarity
-  myIMU.intConf(123, 1, 10, HIGH);
 
   uint8_t readData = 0;
 
@@ -53,34 +50,41 @@ void setup()
 
 void loop()
 {
-
+  // Take IMU out of standby
   myIMU.standby(false);
 
   int16_t dataHighres = 0;
 
-  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_X_L) != 0)
-
+  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_X_L) != 0) {
     Serial.print(" Acceleration X RAW = ");
-  Serial.println(dataHighres);
+    Serial.println(dataHighres);
 
-  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Z_L) != 0)
+    // Read accelerometer data in mg as Float
+    Serial.print(" Acceleration X float = ");
+    Serial.println(myIMU.axisAccel(X), 4);
+  }
 
+  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Y_L) != 0) {
+    Serial.print(" Acceleration Y RAW = ");
+    Serial.println(dataHighres);
+
+    // Read accelerometer data in mg as Float
+    Serial.print(" Acceleration Y float = ");
+    Serial.println(myIMU.axisAccel(Y), 4);
+  }
+
+  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Z_L) != 0) {
     Serial.print(" Acceleration Z RAW = ");
-  Serial.println(dataHighres);
+    Serial.println(dataHighres);
 
-  // Read accelerometer data in mg as Float
-  Serial.print(" Acceleration X float = ");
-  Serial.println(myIMU.axisAccel(X), 4);
+    // Read accelerometer data in mg as Float
+    Serial.print(" Acceleration Z float = ");
+    Serial.println(myIMU.axisAccel(Z), 4);
+  }
 
-  // Read accelerometer data in mg as Float
-  Serial.print(" Acceleration Y float = ");
-  Serial.println(myIMU.axisAccel(Y), 4);
-
-  // Read accelerometer data in mg as Float
-  Serial.print(" Acceleration Z float = ");
-  Serial.println(myIMU.axisAccel(Z), 4);
-
+  // Put IMU back into standby
   myIMU.standby(true);
 
+  // Delay so serial data is human readable
   delay(1000);
 }

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -55,7 +55,7 @@ void loop()
 
   int16_t dataHighres = 0;
 
-  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_X_L) != 0) {
+  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_X_L) == 0) {
     Serial.print(" Acceleration X RAW = ");
     Serial.println(dataHighres);
 
@@ -64,7 +64,7 @@ void loop()
     Serial.println(myIMU.axisAccel(X), 4);
   }
 
-  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Y_L) != 0) {
+  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Y_L) == 0) {
     Serial.print(" Acceleration Y RAW = ");
     Serial.println(dataHighres);
 
@@ -73,7 +73,7 @@ void loop()
     Serial.println(myIMU.axisAccel(Y), 4);
   }
 
-  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Z_L) != 0) {
+  if (myIMU.readRegisterInt16(&dataHighres, KXTJ3_OUT_Z_L) == 0) {
     Serial.print(" Acceleration Z RAW = ");
     Serial.println(dataHighres);
 

--- a/examples/Basic/Basic.ino
+++ b/examples/Basic/Basic.ino
@@ -9,21 +9,15 @@ Uses Wire.h for i2c operation
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
-// Accelerometer provides different power modes by changing output resolution
-// bit
-#define LOW_POWER
-//#define HIGH_RESOLUTION
-
-// Enable Serial debug on Serial UART to see registers written
-#define KXTJ3_DEBUG Serial
-
 // Include the KXTJ3-1057 library (includes Wire.h)
 #include "kxtj3-1057.h"
 
 float sampleRate =
     6.25; // HZ - Samples per second - 0.781, 1.563, 3.125, 6.25, 12.5, 25, 50,
           // 100, 200, 400, 800, 1600Hz
+          // Sample rates ≥ 400Hz force High Resolution mode on
 uint8_t accelRange = 2; // Accelerometer range = 2, 4, 8, 16g
+bool highRes = false; // High Resolution mode on/off
 
 KXTJ3 myIMU(0x0E); // Address can be 0x0E or 0x0F
 
@@ -34,7 +28,7 @@ void setup()
   Serial.begin(115200);
   delay(1000); // wait until serial is open...
 
-  if (myIMU.begin(sampleRate, accelRange) != 0) {
+  if (myIMU.begin(sampleRate, accelRange, highRes) != 0) {
     Serial.println("Failed to initialize IMU.");
   } else {
     Serial.println("IMU initialized.");

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -10,9 +10,10 @@ Uses Wire.h for i2c operation
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
-#include "Wire.h"
 #include "kxtj3-1057.h"
 #include "stdint.h"
+
+#include "Wire.h"
 
 //****************************************************************************//
 //

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -10,9 +10,9 @@ Uses Wire.h for i2c operation
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
+#include "Wire.h"
 #include "kxtj3-1057.h"
 #include "stdint.h"
-#include "Wire.h"
 
 //****************************************************************************//
 //

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -10,6 +10,8 @@ Uses Wire.h for i2c operation
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
+#define KXTJ3_DEBUG Serial
+
 #include "kxtj3-1057.h"
 #include "stdint.h"
 
@@ -23,17 +25,16 @@ Distributed as-is; no warranty is given.
 KXTJ3::KXTJ3(uint8_t inputArg = 0x0E) { I2CAddress = inputArg; }
 
 kxtj3_status_t KXTJ3::begin(float SampleRate, uint8_t accRange, bool highResSet,
-                            bool debugSet, HardwareSerial *port)
+                            bool debugSet)
 {
   kxtj3_status_t returnError = IMU_SUCCESS;
   accelSampleRate            = SampleRate;
   accelRange                 = accRange;
   highRes                    = highResSet;
   debugMode                  = debugSet;
-  debugPort                  = port;
 
   if (debugMode) {
-    debugPort->println("Configuring IMU");
+    KXTJ3_DEBUG.println("Configuring IMU");
   }
 
   Wire.begin();
@@ -69,7 +70,7 @@ kxtj3_status_t KXTJ3::begin(float SampleRate, uint8_t accRange, bool highResSet,
   }
 
   if (debugMode) {
-    debugPort->println("Apply settings");
+    KXTJ3_DEBUG.println("Apply settings");
   }
   applySettings();
 
@@ -144,10 +145,10 @@ kxtj3_status_t KXTJ3::readRegister(uint8_t *outputPointer, uint8_t offset)
   }
 
   if (debugMode) {
-    debugPort->print("Read register 0x");
-    debugPort->print(offset);
-    debugPort->print(" = ");
-    debugPort->println(result);
+    KXTJ3_DEBUG.print("Read register 0x");
+    KXTJ3_DEBUG.print(offset);
+    KXTJ3_DEBUG.print(" = ");
+    KXTJ3_DEBUG.println(result);
   }
 
   *outputPointer = result;
@@ -170,10 +171,10 @@ kxtj3_status_t KXTJ3::readRegisterInt16(int16_t *outputPointer, uint8_t offset)
   int16_t output = (int16_t)myBuffer[0] | int16_t(myBuffer[1] << 8);
 
   if (debugMode && returnError == IMU_SUCCESS) {
-    debugPort->print("12 bit from 0x");
-    debugPort->print(offset);
-    debugPort->print(" = ");
-    debugPort->println(output);
+    KXTJ3_DEBUG.print("12 bit from 0x");
+    KXTJ3_DEBUG.print(offset);
+    KXTJ3_DEBUG.print(" = ");
+    KXTJ3_DEBUG.println(output);
   }
 
   *outputPointer = output;
@@ -446,8 +447,8 @@ void KXTJ3::applySettings(void)
 
   // Now, write the patched together data
   if (debugMode) {
-    debugPort->print("KXTJ3_DATA_CTRL_REG: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_DATA_CTRL_REG: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
   writeRegister(KXTJ3_DATA_CTRL_REG, dataToWrite);
 
@@ -458,7 +459,7 @@ void KXTJ3::applySettings(void)
 
   if (highRes) {
     if (debugMode) {
-      debugPort->println("High Resolution set");
+      KXTJ3_DEBUG.println("High Resolution set");
     }
     dataToWrite = 0xC0;
   }
@@ -482,8 +483,8 @@ void KXTJ3::applySettings(void)
 
   // Now, write the patched together data
   if (debugMode) {
-    debugPort->print("KXTJ3_CTRL_REG1: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_CTRL_REG1: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
   writeRegister(KXTJ3_CTRL_REG1, dataToWrite);
   startupDelay();
@@ -510,8 +511,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
     dataToWrite |= (0x01 << 4); // Active HIGH
 
   if (debugMode) {
-    debugPort->print("KXTJ3_INT_CTRL_REG1: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_INT_CTRL_REG1: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_INT_CTRL_REG1, dataToWrite);
@@ -592,8 +593,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = 0xBF; // enable interrupt on all axis any direction - Unlatched
 
   if (debugMode) {
-    debugPort->print("KXTJ3_INT_CTRL_REG1: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_INT_CTRL_REG1: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_INT_CTRL_REG2, dataToWrite);
@@ -607,8 +608,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = (uint8_t)(threshold >> 4);
 
   if (debugMode) {
-    debugPort->print("KXTJ3_WAKEUP_THRD_H: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_WAKEUP_THRD_H: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_WAKEUP_THRD_H, dataToWrite);
@@ -620,8 +621,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = (uint8_t)(threshold << 4);
 
   if (debugMode) {
-    debugPort->print("KXTJ3_WAKEUP_THRD_L: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_WAKEUP_THRD_L: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_WAKEUP_THRD_L, dataToWrite);
@@ -637,8 +638,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = moveDur;
 
   if (debugMode) {
-    debugPort->print("KXTJ3_WAKEUP_COUNTER: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_WAKEUP_COUNTER: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_WAKEUP_COUNTER, dataToWrite);
@@ -654,8 +655,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = naDur;
 
   if (debugMode) {
-    debugPort->print("KXTJ3_NA_COUNTER: 0x");
-    debugPort->println(dataToWrite);
+    KXTJ3_DEBUG.print("KXTJ3_NA_COUNTER: 0x");
+    KXTJ3_DEBUG.println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_NA_COUNTER, dataToWrite);

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -23,7 +23,7 @@ Distributed as-is; no warranty is given.
 KXTJ3::KXTJ3(uint8_t inputArg = 0x0E) { I2CAddress = inputArg; }
 
 kxtj3_status_t KXTJ3::begin(float SampleRate, uint8_t accRange, bool highResSet,
-                            bool debugSet, HardwareSerial &port)
+                            bool debugSet, HardwareSerial *port)
 {
   kxtj3_status_t returnError = IMU_SUCCESS;
   accelSampleRate            = SampleRate;
@@ -33,7 +33,7 @@ kxtj3_status_t KXTJ3::begin(float SampleRate, uint8_t accRange, bool highResSet,
   debugPort                  = port;
 
   if (debugMode) {
-    debugPort.println("Configuring IMU");
+    debugPort->println("Configuring IMU");
   }
 
   Wire.begin();
@@ -69,7 +69,7 @@ kxtj3_status_t KXTJ3::begin(float SampleRate, uint8_t accRange, bool highResSet,
   }
 
   if (debugMode) {
-    debugPort.println("Apply settings");
+    debugPort->println("Apply settings");
   }
   applySettings();
 
@@ -144,10 +144,10 @@ kxtj3_status_t KXTJ3::readRegister(uint8_t *outputPointer, uint8_t offset)
   }
 
   if (debugMode) {
-    debugPort.print("Read register 0x");
-    debugPort.print(offset);
-    debugPort.print(" = ");
-    debugPort.println(result);
+    debugPort->print("Read register 0x");
+    debugPort->print(offset);
+    debugPort->print(" = ");
+    debugPort->println(result);
   }
 
   *outputPointer = result;
@@ -170,10 +170,10 @@ kxtj3_status_t KXTJ3::readRegisterInt16(int16_t *outputPointer, uint8_t offset)
   int16_t output = (int16_t)myBuffer[0] | int16_t(myBuffer[1] << 8);
 
   if (debugMode && returnError == IMU_SUCCESS) {
-    debugPort.print("12 bit from 0x");
-    debugPort.print(offset);
-    debugPort.print(" = ");
-    debugPort.println(output);
+    debugPort->print("12 bit from 0x");
+    debugPort->print(offset);
+    debugPort->print(" = ");
+    debugPort->println(output);
   }
 
   *outputPointer = output;
@@ -446,8 +446,8 @@ void KXTJ3::applySettings(void)
 
   // Now, write the patched together data
   if (debugMode) {
-    debugPort.print("KXTJ3_DATA_CTRL_REG: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_DATA_CTRL_REG: 0x");
+    debugPort->println(dataToWrite);
   }
   writeRegister(KXTJ3_DATA_CTRL_REG, dataToWrite);
 
@@ -458,7 +458,7 @@ void KXTJ3::applySettings(void)
 
   if (highRes) {
     if (debugMode) {
-      debugPort.println("High Resolution set");
+      debugPort->println("High Resolution set");
     }
     dataToWrite = 0xC0;
   }
@@ -482,8 +482,8 @@ void KXTJ3::applySettings(void)
 
   // Now, write the patched together data
   if (debugMode) {
-    debugPort.print("KXTJ3_CTRL_REG1: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_CTRL_REG1: 0x");
+    debugPort->println(dataToWrite);
   }
   writeRegister(KXTJ3_CTRL_REG1, dataToWrite);
   startupDelay();
@@ -510,8 +510,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
     dataToWrite |= (0x01 << 4); // Active HIGH
 
   if (debugMode) {
-    debugPort.print("KXTJ3_INT_CTRL_REG1: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_INT_CTRL_REG1: 0x");
+    debugPort->println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_INT_CTRL_REG1, dataToWrite);
@@ -592,8 +592,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = 0xBF; // enable interrupt on all axis any direction - Unlatched
 
   if (debugMode) {
-    debugPort.print("KXTJ3_INT_CTRL_REG1: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_INT_CTRL_REG1: 0x");
+    debugPort->println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_INT_CTRL_REG2, dataToWrite);
@@ -607,8 +607,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = (uint8_t)(threshold >> 4);
 
   if (debugMode) {
-    debugPort.print("KXTJ3_WAKEUP_THRD_H: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_WAKEUP_THRD_H: 0x");
+    debugPort->println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_WAKEUP_THRD_H, dataToWrite);
@@ -620,8 +620,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = (uint8_t)(threshold << 4);
 
   if (debugMode) {
-    debugPort.print("KXTJ3_WAKEUP_THRD_L: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_WAKEUP_THRD_L: 0x");
+    debugPort->println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_WAKEUP_THRD_L, dataToWrite);
@@ -637,8 +637,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = moveDur;
 
   if (debugMode) {
-    debugPort.print("KXTJ3_WAKEUP_COUNTER: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_WAKEUP_COUNTER: 0x");
+    debugPort->println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_WAKEUP_COUNTER, dataToWrite);
@@ -654,8 +654,8 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   dataToWrite = naDur;
 
   if (debugMode) {
-    debugPort.print("KXTJ3_NA_COUNTER: 0x");
-    debugPort.println(dataToWrite);
+    debugPort->print("KXTJ3_NA_COUNTER: 0x");
+    debugPort->println(dataToWrite);
   }
 
   returnError = writeRegister(KXTJ3_NA_COUNTER, dataToWrite);

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -477,10 +477,10 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
 
   // Build INT_CTRL_REG1
 
-  uint8_t dataToWrite = 0x22; // Interrupt enabled, active LOW, non-latched
+  uint8_t dataToWrite = 0x20; // Interrupt enabled, active LOW, non-latched
 
   if (polarity == HIGH)
-    dataToWrite |= (0x01 << 5); // Active HIGH
+    dataToWrite |= (0x01 << 4); // Active HIGH
 
   _DEBBUG("KXTJ3_INT_CTRL_REG1: 0x", dataToWrite);
   returnError = writeRegister(KXTJ3_INT_CTRL_REG1, dataToWrite);
@@ -494,6 +494,47 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
   _reg1 |= (0x01 << 1);
 
   returnError = writeRegister(KXTJ3_CTRL_REG1, _reg1);
+
+  // Sets the Data Rate for the Wake-Up (motion detect) function to match ODR
+  // Start by checking DATA_CTRL_REG for the current ODR
+
+  returnError = readRegister(&_reg1, KXTJ3_DATA_CTRL_REG);
+
+  // Set ODRWU based on ODR
+  // Maximum ODRWU is 100 Hz
+
+  switch (_reg1) {
+  case 0x09:
+    dataToWrite = 0x01;
+    break;
+  case 0x0A:
+    dataToWrite = 0x02;
+    break;
+  case 0x0B:
+    dataToWrite = 0x03;
+    break;
+  case 0x00:
+    dataToWrite = 0x04;
+    break;
+  case 0x01:
+    dataToWrite = 0x05;
+    break;
+  case 0x02:
+    dataToWrite = 0x06;
+    break;
+  case 0x03:
+  case 0x04:
+  case 0x05:
+  case 0x06:
+  case 0x07:
+    dataToWrite = 0x07;
+    break;
+  default:
+    dataToWrite = 0x00;
+    break;
+  }
+
+  returnError = writeRegister(KXTJ3_CTRL_REG2, dataToWrite);
 
   // Build INT_CTRL_REG2
 

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -12,7 +12,6 @@ Distributed as-is; no warranty is given.
 
 #include "kxtj3-1057.h"
 #include "stdint.h"
-
 #include "Wire.h"
 
 //****************************************************************************//
@@ -470,7 +469,7 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
                               uint8_t naDur, bool polarity)
 {
   // Note that to properly change the value of this register, the PC1 bit in
-  // CTRL_REG1must first be set to “0”.
+  // CTRL_REG1 must first be set to “0”.
   standby(true);
 
   kxtj3_status_t returnError = IMU_SUCCESS;
@@ -505,32 +504,32 @@ kxtj3_status_t KXTJ3::intConf(uint16_t threshold, uint8_t moveDur,
 
   switch (_reg1) {
   case 0x09:
-    dataToWrite = 0x01;
+    dataToWrite = 0x01; // 1.563 Hz
     break;
   case 0x0A:
-    dataToWrite = 0x02;
+    dataToWrite = 0x02; // 3.125 Hz
     break;
   case 0x0B:
-    dataToWrite = 0x03;
+    dataToWrite = 0x03; // 6.25 Hz
     break;
   case 0x00:
-    dataToWrite = 0x04;
+    dataToWrite = 0x04; // 12.5 Hz
     break;
   case 0x01:
-    dataToWrite = 0x05;
+    dataToWrite = 0x05; // 25 Hz
     break;
   case 0x02:
-    dataToWrite = 0x06;
+    dataToWrite = 0x06; // 50 Hz
     break;
   case 0x03:
   case 0x04:
   case 0x05:
   case 0x06:
   case 0x07:
-    dataToWrite = 0x07;
+    dataToWrite = 0x07; // 100 Hz
     break;
   default:
-    dataToWrite = 0x00;
+    dataToWrite = 0x00; // 0.781 Hz
     break;
   }
 

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -21,30 +21,6 @@ Distributed as-is; no warranty is given.
 #include "WProgram.h"
 #endif
 
-#if defined LOW_POWER && defined HIGH_RESOLUTION
-#error Please choose between the 2 resolution types
-#endif
-
-#ifdef KXTJ3_DEBUG
-namespace
-{
-  template <typename T> static void _DEBBUG(T last)
-  {
-    KXTJ3_DEBUG.println(last);
-  }
-
-  template <typename T, typename... Args>
-  static void _DEBBUG(T head, Args... tail)
-  {
-    KXTJ3_DEBUG.print(head);
-    KXTJ3_DEBUG.print(' ');
-    _DEBBUG(tail...);
-  }
-}
-#else
-#define _DEBBUG(...)
-#endif
-
 // Print variable name
 #define getName(var) #var
 
@@ -75,7 +51,9 @@ class KXTJ3
   Sample Rate - 0.781, 1.563, 3.125, 6.25, 12.5, 25, 50, 100, 200, 400, 800,
   1600Hz Output Data Rates ≥400Hz will force device into High Resolution mode
   */
-  kxtj3_status_t begin(float SampleRate, uint8_t accRange);
+  kxtj3_status_t begin(float SampleRate, uint8_t accRange,
+                       bool highResSet = false, bool debugSet = false,
+                       HardwareSerial &port = Serial);
 
   // readRegister reads one 8-bit register
   kxtj3_status_t readRegister(uint8_t *outputPointer, uint8_t offset);
@@ -108,11 +86,9 @@ class KXTJ3
   kxtj3_status_t standby(bool _en = true);
 
   private:
-#ifdef HIGH_RESOLUTION
-  bool highRes = true;
-#else
-  bool highRes = false;
-#endif
+  bool highRes              = false;
+  bool debugMode            = false;
+  HardwareSerial &debugPort = Serial;
   uint8_t I2CAddress;
   float accelSampleRate; // Sample Rate - 0.781, 1.563, 3.125, 6.25, 12.5, 25,
                          // 50, 100, 200, 400, 800, 1600Hz

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -28,13 +28,13 @@ Distributed as-is; no warranty is given.
 #ifdef KXTJ3_DEBUG
 namespace
 {
-  template <typename T> static void _DEBBUG(T last) { Serial.println(last); }
+  template <typename T> static void _DEBBUG(T last) { KXTJ3_DEBUG.println(last); }
 
   template <typename T, typename... Args>
   static void _DEBBUG(T head, Args... tail)
   {
-    Serial.print(head);
-    Serial.print(' ');
+    KXTJ3_DEBUG.print(head);
+    KXTJ3_DEBUG.print(' ');
     _DEBBUG(tail...);
   }
 }

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -28,7 +28,10 @@ Distributed as-is; no warranty is given.
 #ifdef KXTJ3_DEBUG
 namespace
 {
-  template <typename T> static void _DEBBUG(T last) { KXTJ3_DEBUG.println(last); }
+  template <typename T> static void _DEBBUG(T last)
+  {
+    KXTJ3_DEBUG.println(last);
+  }
 
   template <typename T, typename... Args>
   static void _DEBBUG(T head, Args... tail)

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -53,7 +53,7 @@ class KXTJ3
   */
   kxtj3_status_t begin(float SampleRate, uint8_t accRange,
                        bool highResSet = false, bool debugSet = false,
-                       HardwareSerial &port = Serial);
+                       HardwareSerial *port = &Serial);
 
   // readRegister reads one 8-bit register
   kxtj3_status_t readRegister(uint8_t *outputPointer, uint8_t offset);
@@ -88,7 +88,7 @@ class KXTJ3
   private:
   bool highRes              = false;
   bool debugMode            = false;
-  HardwareSerial &debugPort = Serial;
+  HardwareSerial *debugPort = &Serial;
   uint8_t I2CAddress;
   float accelSampleRate; // Sample Rate - 0.781, 1.563, 3.125, 6.25, 12.5, 25,
                          // 50, 100, 200, 400, 800, 1600Hz

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -52,8 +52,7 @@ class KXTJ3
   1600Hz Output Data Rates ≥400Hz will force device into High Resolution mode
   */
   kxtj3_status_t begin(float SampleRate, uint8_t accRange,
-                       bool highResSet = false, bool debugSet = false,
-                       HardwareSerial *port = &Serial);
+                       bool highResSet = false, bool debugSet = false);
 
   // readRegister reads one 8-bit register
   kxtj3_status_t readRegister(uint8_t *outputPointer, uint8_t offset);
@@ -86,9 +85,8 @@ class KXTJ3
   kxtj3_status_t standby(bool _en = true);
 
   private:
-  bool highRes              = false;
-  bool debugMode            = false;
-  HardwareSerial *debugPort = &Serial;
+  bool highRes   = false;
+  bool debugMode = false;
   uint8_t I2CAddress;
   float accelSampleRate; // Sample Rate - 0.781, 1.563, 3.125, 6.25, 12.5, 25,
                          // 50, 100, 200, 400, 800, 1600Hz


### PR DESCRIPTION
Corrects interrupt setter so that it does not try to set the STPOL bit and correctly sets the IEA bit for INT pin polarity, makes it so that the interrupt data rate will try to match the user-specified IMU data rate (up to 100 Hz) as this is what the current documentation states will happen, and corrects KXTJ3_DEBUG preprocessor directive so that it will obey the Serial port that was passed to it by the user in their sketch.

Also updates basic example sketch to remove interrupt handling (this is not a 'basic' function and did not work in the example sketch as-written), corrects the successful data read checks for reading each of the axes in loop(), and corrects as well as adds comments to the sketch.

Eventually the intention is to implement arbitrary user-configurable Wake-Up Output Data Rates as well as additional interrupt modes, but this PR will allow the current implementation to match its current documentation.