### PR TITLE
Code Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Please note that in the context of Interrupt Duration, only Sample Rates up to 1
 
 > This value can be anything from 1 to 255
 
-* i.e 5 event_counts / 6.25 Hz = 0.8 seconds
+* i.e. 5 event_counts / 6.25 Hz = 0.8 seconds
 
 ### Non-Activity Duration
 
@@ -142,7 +142,7 @@ As with Interrupt Duration, please note that only Sample Rates up to 100 Hz are 
 
 > This value can be anything from 1 to 255
 
-* i.e 5 event_counts / 6.25 Hz = 0.8 seconds
+* i.e. 5 event_counts / 6.25 Hz = 0.8 seconds
 
 ## Credits
 

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -796,9 +796,9 @@ kxtj3_status_t KXTJ3::intConf(int16_t threshold, uint8_t moveDur, uint8_t naDur,
   return returnError;
 }
 
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
-                                     uint8_t third, uint8_t fourth,
-                                     uint8_t fifth)
+kxtj3_status_t KXTJ3::intDisableAxis(wu_axis_t first, wu_axis_t second,
+                                     wu_axis_t third, wu_axis_t fourth,
+                                     wu_axis_t fifth)
 {
   // Create temporary variables
   kxtj3_status_t returnError = IMU_SUCCESS;
@@ -813,8 +813,8 @@ kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
   if (bitCheck & (0x01 << 7))
     dataToWrite |= (0x01 << 7);
 
-  if (first == NONE || second == NONE || third == NONE || fourth == NONE ||
-      fifth == NONE) {
+  if (first & NONE || second & NONE || third & NONE || fourth & NONE ||
+      fifth & NONE) {
     // Rebuild INT_CTRL_REG2 with 0x00 using XOR to enable all axes
     dataToWrite ^= temp;
   } else {
@@ -840,24 +840,24 @@ kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
   return returnError;
 }
 
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first)
+kxtj3_status_t KXTJ3::intDisableAxis(wu_axis_t first)
 {
   return intDisableAxis(first, BLANK, BLANK, BLANK, BLANK);
 }
 
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second)
+kxtj3_status_t KXTJ3::intDisableAxis(wu_axis_t first, wu_axis_t second)
 {
   return intDisableAxis(first, second, BLANK, BLANK, BLANK);
 }
 
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
-                                     uint8_t third)
+kxtj3_status_t KXTJ3::intDisableAxis(wu_axis_t first, wu_axis_t second,
+                                     wu_axis_t third)
 {
   return intDisableAxis(first, second, third, BLANK, BLANK);
 }
 
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
-                                     uint8_t third, uint8_t fourth)
+kxtj3_status_t KXTJ3::intDisableAxis(wu_axis_t first, wu_axis_t second,
+                                     wu_axis_t third, wu_axis_t fourth)
 {
   return intDisableAxis(first, second, third, fourth, BLANK);
 }

--- a/src/kxtj3-1057.cpp
+++ b/src/kxtj3-1057.cpp
@@ -570,10 +570,10 @@ kxtj3_status_t KXTJ3::enable14Bit(uint8_t accRange)
 //  Configure interrupt, stop or move, threshold and duration
 //	Duration, steps and maximum values depend on the ODR chosen.
 //****************************************************************************//
-kxtj3_status_t KXTJ3::intConf(int16_t threshold, uint8_t moveDur,
-                              uint8_t naDur, bool polarity, float wuRate,
-                              bool latched, bool pulsed, bool motion,
-                              bool dataReady, bool intPin)
+kxtj3_status_t KXTJ3::intConf(int16_t threshold, uint8_t moveDur, uint8_t naDur,
+                              bool polarity, float wuRate, bool latched,
+                              bool pulsed, bool motion, bool dataReady,
+                              bool intPin)
 {
   kxtj3_status_t returnError = IMU_SUCCESS;
 
@@ -796,20 +796,38 @@ kxtj3_status_t KXTJ3::intConf(int16_t threshold, uint8_t moveDur,
   return returnError;
 }
 
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first)
+kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
+                                     uint8_t third, uint8_t fourth,
+                                     uint8_t fifth)
 {
   // Create temporary variables
   kxtj3_status_t returnError = IMU_SUCCESS;
+  uint8_t temp               = 0x00;
   uint8_t dataToWrite        = 0b00111111;
   uint8_t bitCheck;
 
   // Check to see if ULMODE bit is set and set if so
   returnError = readRegister(&bitCheck, KXTJ3_INT_CTRL_REG2);
+  if (returnError != IMU_SUCCESS)
+    return returnError;
   if (bitCheck & (0x01 << 7))
     dataToWrite |= (0x01 << 7);
 
-  // Rebuild INT_CTRL_REG2 with new axis data using XOR
-  dataToWrite ^= first;
+  if (first == NONE || second == NONE || third == NONE || fourth == NONE ||
+      fifth == NONE) {
+    // Rebuild INT_CTRL_REG2 with 0x00 using XOR to enable all axes
+    dataToWrite ^= temp;
+  } else {
+    // combine the requested axes
+    temp |= first;
+    temp |= second;
+    temp |= third;
+    temp |= fourth;
+    temp |= fifth;
+
+    // Rebuild INT_CTRL_REG2 with new axis data using XOR
+    dataToWrite ^= temp;
+  }
 
   // Write the new values to INT_CTRL_REG2
   if (debugMode) {
@@ -822,83 +840,26 @@ kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first)
   return returnError;
 }
 
+kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first)
+{
+  return intDisableAxis(first, BLANK, BLANK, BLANK, BLANK);
+}
+
 kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second)
 {
-  // Create temporary variables
-  kxtj3_status_t returnError = IMU_SUCCESS;
-  uint8_t temp               = 0x00;
-  if (first == NONE || second == NONE) {
-    returnError = intDisableAxis(temp); // send 0x00 to enable all axes
-  } else {
-    // combine the requested axes and submit to base function
-    temp |= first;
-    temp |= second;
-    returnError = intDisableAxis(temp);
-  }
-
-  return returnError;
+  return intDisableAxis(first, second, BLANK, BLANK, BLANK);
 }
 
 kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
                                      uint8_t third)
 {
-  // Create temporary variables
-  kxtj3_status_t returnError = IMU_SUCCESS;
-  uint8_t temp               = 0x00;
-  if (first == NONE || second == NONE || third == NONE) {
-    returnError = intDisableAxis(temp); // send 0x00 to enable all axes
-  } else {
-    // combine the requested axes and submit to base function
-    temp |= first;
-    temp |= second;
-    temp |= third;
-    returnError = intDisableAxis(temp);
-  }
-
-  return returnError;
+  return intDisableAxis(first, second, third, BLANK, BLANK);
 }
 
 kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
                                      uint8_t third, uint8_t fourth)
 {
-  // Create temporary variables
-  kxtj3_status_t returnError = IMU_SUCCESS;
-  uint8_t temp               = 0x00;
-  if (first == NONE || second == NONE || third == NONE || fourth == NONE) {
-    returnError = intDisableAxis(temp); // send 0x00 to enable all axes
-  } else {
-    // combine the requested axes and submit to base function
-    temp |= first;
-    temp |= second;
-    temp |= third;
-    temp |= fourth;
-    returnError = intDisableAxis(temp);
-  }
-
-  return returnError;
-}
-
-kxtj3_status_t KXTJ3::intDisableAxis(uint8_t first, uint8_t second,
-                                     uint8_t third, uint8_t fourth,
-                                     uint8_t fifth)
-{
-  // Create temporary variables
-  kxtj3_status_t returnError = IMU_SUCCESS;
-  uint8_t temp               = 0x00;
-  if (first == NONE || second == NONE || third == NONE || fourth == NONE ||
-      fifth == NONE) {
-    returnError = intDisableAxis(temp); // send 0x00 to enable all axes
-  } else {
-    // combine the requested axes and submit to base function
-    temp |= first;
-    temp |= second;
-    temp |= third;
-    temp |= fourth;
-    temp |= fifth;
-    returnError = intDisableAxis(temp);
-  }
-
-  return returnError;
+  return intDisableAxis(first, second, third, fourth, BLANK);
 }
 
 bool KXTJ3::dataReady(void)

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -42,13 +42,14 @@ typedef enum {
 } axis_t;
 
 typedef enum {
-  NONE = 0,
-  ZPOS = 1,
-  ZNEG = 2,
-  YPOS = 4,
-  YNEG = 8,
-  XPOS = 16,
-  XNEG = 32,
+  BLANK = 0,
+  ZPOS  = 1,
+  ZNEG  = 2,
+  YPOS  = 4,
+  YNEG  = 8,
+  XPOS  = 16,
+  XNEG  = 32,
+  NONE  = 64,
 } wu_axis_t;
 
 class KXTJ3

--- a/src/kxtj3-1057.h
+++ b/src/kxtj3-1057.h
@@ -98,13 +98,15 @@ class KXTJ3
                          bool motion = true, bool dataReady = false,
                          bool intPin = true);
 
-  kxtj3_status_t intDisableAxis(uint8_t first);
-  kxtj3_status_t intDisableAxis(uint8_t first, uint8_t second);
-  kxtj3_status_t intDisableAxis(uint8_t first, uint8_t second, uint8_t third);
-  kxtj3_status_t intDisableAxis(uint8_t first, uint8_t second, uint8_t third,
-                                uint8_t fourth);
-  kxtj3_status_t intDisableAxis(uint8_t first, uint8_t second, uint8_t third,
-                                uint8_t fourth, uint8_t fifth);
+  kxtj3_status_t intDisableAxis(wu_axis_t first);
+  kxtj3_status_t intDisableAxis(wu_axis_t first, wu_axis_t second);
+  kxtj3_status_t intDisableAxis(wu_axis_t first, wu_axis_t second,
+                                wu_axis_t third);
+  kxtj3_status_t intDisableAxis(wu_axis_t first, wu_axis_t second,
+                                wu_axis_t third, wu_axis_t fourth);
+  kxtj3_status_t intDisableAxis(wu_axis_t first, wu_axis_t second,
+                                wu_axis_t third, wu_axis_t fourth,
+                                wu_axis_t fifth);
 
   // Checks to see if new data is ready (only works if DRDY interrupt enabled)
   bool dataReady(void);


### PR DESCRIPTION
This commit cleans up the intDisableAxis functions so that there is only a single primary function and the remaining four overloaded functions simply call the main 5-parameter function with "BLANK" in the empty parameter spots. It also enforces the wu_axis_t datatype for intDisableAxis rather than casting to uint8_t, and fixes a minor typo in README.md.